### PR TITLE
Dk sort before merge

### DIFF
--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -49,9 +49,16 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
         multiple: it[1].size() > 1
     }.set{bam_to_merge}
 
+    /*
     bam_to_merge_sorted = SORT_BAM(bam_to_merge.multiple)
-
     MERGE_BAM(bam_to_merge_sorted, [], [])
+    */
+
+    // dk
+    bam_to_merge.multiple.view {"***** bam_to_merge.multiple: $it"}
+    MERGE_BAM(bam_to_merge.multiple, [], [])
+    // dk
+
     INDEX_MERGE_BAM(bam_to_merge.single.mix(MERGE_BAM.out.bam))
 
     bam_bai = bam_to_merge.single.map{meta, bam -> [meta, bam[0]]}

--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -21,6 +21,8 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
         multiple: it[1].size() > 1
     }.set{bam_to_merge}
 
+    // TODO dk: sort before merge
+
     MERGE_BAM(bam_to_merge.multiple, [], [])
     INDEX_MERGE_BAM(bam_to_merge.single.mix(MERGE_BAM.out.bam))
 

--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -22,6 +22,7 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
     }.set{bam_to_merge}
 
     // TODO dk: sort before merge
+    //
 
     MERGE_BAM(bam_to_merge.multiple, [], [])
     INDEX_MERGE_BAM(bam_to_merge.single.mix(MERGE_BAM.out.bam))

--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -11,14 +11,12 @@ include { SAMTOOLS_MERGE as MERGE_BAM       } from '../../../modules/nf-core/sam
 process SORT_BAM {
     
     input:
-    tuple val(meta), path(input_files, stageAs: "?/*")
+
+    tuple val(meta), path(input_files)
  
-    // TODO: remove stageAs?
-
     output:
-    tuple val(meta), path(output_files), optional:true, emit: bam
 
-    // TODO: remove optional, emit?
+    tuple val(meta), path(output_files)
 
     script:
 
@@ -29,16 +27,10 @@ process SORT_BAM {
     // We want to sort based on the filename, so we remove
     // the relative path to the bam file for the sort criterion.
 
-    // this works, but danger of array out of bounds
-    //output_files = input_files.sort {it.name.split('/')[1]}
-
     output_files = input_files.sort {it.name.replaceAll('.*/','')}
 
-    println "***** input_files: " + input_files
-    println "***** output_files: " + output_files
-
     """
-    echo '***** sorting'
+    echo '***** SORT_BAM'
     """
 }
 
@@ -57,18 +49,7 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
         multiple: it[1].size() > 1
     }.set{bam_to_merge}
 
-    // TODO dk: sort before merge
-    //
-
-    // TODO: remove
-    bam_to_merge.single.view { "***** bam_to_merge.single: $it" }
-    bam_to_merge.multiple.view { "***** bam_to_merge.multiple: $it" }
-
     bam_to_merge_sorted = SORT_BAM(bam_to_merge.multiple)
-
-    // TODO: remove
-    bam_to_merge_sorted.view { "***** bam_to_merge_sorted: $it" }
-    SORT_BAM.out.bam.view { "***** SORT_BAM.out.bam: $it" }
 
     MERGE_BAM(bam_to_merge_sorted, [], [])
     INDEX_MERGE_BAM(bam_to_merge.single.mix(MERGE_BAM.out.bam))
@@ -76,9 +57,6 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
     bam_bai = bam_to_merge.single.map{meta, bam -> [meta, bam[0]]}
         .mix(MERGE_BAM.out.bam)
         .join(INDEX_MERGE_BAM.out.bai)
-
-    //dk
-    bam_bai.view { "***** bam_bai: $it" }
 
     // Gather versions of all tools used
     ch_versions = ch_versions.mix(INDEX_MERGE_BAM.out.versions.first())

--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -22,9 +22,17 @@ process SORT_BAM {
 
     script:
 
-    // TODO: document this sort criterion 
-    // (BAM files staged separate subdirs of workdir)
-    output_files = input_files.sort {it.name.split('/')[1]}
+    // BAM files are staged in subdirs of the work directory:
+    //   1/file_234.bam 
+    //   2/file_123.bam
+    //   ...
+    // We want to sort based on the filename, so we remove
+    // the relative path to the bam file for the sort criterion.
+
+    // this works, but danger of array out of bounds
+    //output_files = input_files.sort {it.name.split('/')[1]}
+
+    output_files = input_files.sort {it.name.replaceAll('.*/','')}
 
     println "***** input_files: " + input_files
     println "***** output_files: " + output_files

--- a/subworkflows/local/bam_merge_index_samtools/main.nf
+++ b/subworkflows/local/bam_merge_index_samtools/main.nf
@@ -7,34 +7,6 @@
 include { SAMTOOLS_INDEX as INDEX_MERGE_BAM } from '../../../modules/nf-core/samtools/index/main'
 include { SAMTOOLS_MERGE as MERGE_BAM       } from '../../../modules/nf-core/samtools/merge/main'
 
-
-process SORT_BAM {
-    
-    input:
-
-    tuple val(meta), path(input_files)
- 
-    output:
-
-    tuple val(meta), path(output_files)
-
-    script:
-
-    // BAM files are staged in subdirs of the work directory:
-    //   1/file_234.bam 
-    //   2/file_123.bam
-    //   ...
-    // We want to sort based on the filename, so we remove
-    // the relative path to the bam file for the sort criterion.
-
-    output_files = input_files.sort {it.name.replaceAll('.*/','')}
-
-    """
-    echo '***** SORT_BAM'
-    """
-}
-
-
 workflow BAM_MERGE_INDEX_SAMTOOLS {
     take:
         bam // channel: [mandatory] meta, bam
@@ -49,16 +21,7 @@ workflow BAM_MERGE_INDEX_SAMTOOLS {
         multiple: it[1].size() > 1
     }.set{bam_to_merge}
 
-    /*
-    bam_to_merge_sorted = SORT_BAM(bam_to_merge.multiple)
-    MERGE_BAM(bam_to_merge_sorted, [], [])
-    */
-
-    // dk
-    bam_to_merge.multiple.view {"***** bam_to_merge.multiple: $it"}
     MERGE_BAM(bam_to_merge.multiple, [], [])
-    // dk
-
     INDEX_MERGE_BAM(bam_to_merge.single.mix(MERGE_BAM.out.bam))
 
     bam_bai = bam_to_merge.single.map{meta, bam -> [meta, bam[0]]}

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -413,7 +413,16 @@ workflow SAREK {
         [new_meta, bam]
     }.groupTuple()
 
-    BAM_MERGE_INDEX_SAMTOOLS(ch_bam_mapped)
+    // dk
+    ch_bam_mapped.view { "***** ch_bam_mapped: $it" }
+
+    ch_bam_sorted = ch_bam_mapped.map{ meta, bam -> 
+        [meta, bam.sort {it.name.replaceAll('.*/','')}]
+    }
+    ch_bam_sorted.view { "***** ch_bam_sorted: $it" }
+    // dk
+
+    BAM_MERGE_INDEX_SAMTOOLS(ch_bam_sorted)
 
     BAM_TO_CRAM_MAPPING(BAM_MERGE_INDEX_SAMTOOLS.out.bam_bai, fasta, fasta_fai)
     params.save_output_as_bam ? CHANNEL_ALIGN_CREATE_CSV(BAM_MERGE_INDEX_SAMTOOLS.out.bam_bai) : CHANNEL_ALIGN_CREATE_CSV(BAM_TO_CRAM_MAPPING.out.alignment_index)

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -413,14 +413,18 @@ workflow SAREK {
         [new_meta, bam]
     }.groupTuple()
 
-    // dk
-    ch_bam_mapped.view { "***** ch_bam_mapped: $it" }
+    // Use map operator to sort BAM files by filename before merging.
+    //
+    // BAM files are staged in subdirs of the work directory:
+    //   1/file_234.bam 
+    //   2/file_123.bam
+    //   ...
+    // We want to sort based on the filename, so we remove
+    // the relative path to the bam file for the sort criterion.
 
     ch_bam_sorted = ch_bam_mapped.map{ meta, bam -> 
         [meta, bam.sort {it.name.replaceAll('.*/','')}]
     }
-    ch_bam_sorted.view { "***** ch_bam_sorted: $it" }
-    // dk
 
     BAM_MERGE_INDEX_SAMTOOLS(ch_bam_sorted)
 


### PR DESCRIPTION
This is a change to sort BAM files by filename before merging them into a single BAM file.

The change is contained in the file:
subworkflows/local/bam_merge_index_samtools/main.nf

I added a single process SORT_BAM which operates on the existing channel "bam_to_merge.multiple", returning the new channel "bam_to_merge_sorted" that is passed into MERGE_BAM instead.

The SORT_BAM process uses this Nextflow feature: the "script:" section can include Groovy code that modifies inputs and stages output (the actual script code is just an echo statement).

To verify this change, I first checked the channel output before/after the SORT_BAM process to see that the channel was being sorted properly.  I then ran the pipeline (using the test csv file Xingyao made) multiple times and verified that the clairs output directory was identical on successive runs.

