### PR TITLE
Dk germline stats

### DIFF
--- a/subworkflows/local/bam_variant_calling_somatic_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_all/main.nf
@@ -297,7 +297,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
 
         clairs_vcf = BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.clairs_vcf
         clairs_tbi = BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.clairs_tbi
-        // TODO dk: get clairs_vcf_normal_germline and re-emit
+        clairs_vcf_normal_germline = BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.clairs_vcf_normal_germline
+        clairs_tbi_normal_germline = BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.clairs_tbi_normal_germline
         ch_versions = ch_versions.mix(BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.versions)
     }
 
@@ -324,6 +325,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
     mutect2_tbi
     clairs_vcf
     clairs_tbi
+    clairs_vcf_normal_germline
+    clairs_tbi_normal_germline
     strelka_vcf
     tiddit_vcf
 

--- a/subworkflows/local/bam_variant_calling_somatic_all/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_all/main.nf
@@ -297,6 +297,7 @@ workflow BAM_VARIANT_CALLING_SOMATIC_ALL {
 
         clairs_vcf = BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.clairs_vcf
         clairs_tbi = BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.clairs_tbi
+        // TODO dk: get clairs_vcf_normal_germline and re-emit
         ch_versions = ch_versions.mix(BAM_VARIANT_CALLING_SOMATIC_CLAIRS.out.versions)
     }
 

--- a/subworkflows/local/bam_variant_calling_somatic_clairs/main.nf
+++ b/subworkflows/local/bam_variant_calling_somatic_clairs/main.nf
@@ -63,7 +63,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_CLAIRS {
                         num_intervals:meta.num_intervals,
                         patient:meta.patient,
                         sex:meta.sex,
-                        tumor_id:meta.tumor_id
+                        tumor_id:meta.tumor_id,
+                        variantcaller: "clairs",
                     ]
         [new_meta_normal_germline, vcf_normal_germline]
     }.set{ch_clairs_vcf_normal_germline}
@@ -75,7 +76,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_CLAIRS {
                         num_intervals:meta.num_intervals,
                         patient:meta.patient,
                         sex:meta.sex,
-                        tumor_id:meta.tumor_id
+                        tumor_id:meta.tumor_id,
+                        variantcaller: "clairs",
                     ]
         [new_meta_normal_pileup, vcf_normal_pileup]
     }.set{ch_clairs_vcf_normal_pileup}
@@ -92,7 +94,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_CLAIRS {
                         num_intervals:meta.num_intervals,
                         patient:meta.patient,
                         sex:meta.sex,
-                        tumor_id:meta.tumor_id
+                        tumor_id:meta.tumor_id,
+                        variantcaller: "clairs",
                     ]
             [new_meta_normal_germline, vcf_normal_germline]
         }
@@ -109,7 +112,8 @@ workflow BAM_VARIANT_CALLING_SOMATIC_CLAIRS {
                         num_intervals:meta.num_intervals,
                         patient:meta.patient,
                         sex:meta.sex,
-                        tumor_id:meta.tumor_id
+                        tumor_id:meta.tumor_id,
+                        variantcaller: "clairs",
                     ]
             [new_meta_normal_pileup, vcf_normal_pileup]
         }

--- a/workflows/sarek.nf
+++ b/workflows/sarek.nf
@@ -1146,6 +1146,7 @@ workflow SAREK {
         vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.freebayes_vcf)
         vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.mutect2_vcf)
         vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.clairs_vcf)
+        vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.clairs_vcf_normal_germline)
         vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.manta_vcf)
         vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.strelka_vcf)
         vcf_to_annotate = vcf_to_annotate.mix(BAM_VARIANT_CALLING_SOMATIC_ALL.out.tiddit_vcf)


### PR DESCRIPTION
Added bcftools/vcftools stats for hg002 germline vcf files.

Summary of changes:

1) subworkflows/local/bam_variant_calling_somatic_all/main.nf: 
grab clairs_vcf_normal_germline channels from BAM_VARIANT_CALLING_SOMATIC_CLAIRS output, and re-emit.

2) workflows/sarek.nf:
add clairs_vcf_normal_germline to vcf_to_annotate

3) subworkflows/local/bam_variant_calling_somatic_clairs/main.nf:
added metadata (variantcaller: "clairs") so that reports are created in the "clairs" directory (was "null")

Testing:

I ran the same pipeline test I've been using, and compared output.  The diffs were as expected: 1) new output files for HG002, 2) extra line for HG002 in several text files, 3) no diff in variant calling output, 4) diffs in binary files, and in time/date stamps.



